### PR TITLE
Update `getRoomHashtag` function and add clickable room hashtags

### DIFF
--- a/src/components/sections/SessionCard.tsx
+++ b/src/components/sections/SessionCard.tsx
@@ -129,9 +129,9 @@ const SessionCard: React.FC<SessionCardProps> = ({ session, locale, showDate = f
                       </span>
                     )}
                     {/* ハッシュタグラベル */}
-                    {session.slot.room && getRoomHashtag(session.slot.room.id) && (
+                    {session.slot.room && getRoomHashtag(session.slot.room.id, session.code) && (
                       <span className="inline-flex items-center px-3 py-1 bg-gray-200 text-gray-900 text-sm font-bold rounded-full">
-                        {getRoomHashtag(session.slot.room.id)}
+                        {getRoomHashtag(session.slot.room.id, session.code)}
                       </span>
                     )}
                     {/* レベルラベル */}

--- a/src/components/sections/TalkDetailSection.tsx
+++ b/src/components/sections/TalkDetailSection.tsx
@@ -131,15 +131,15 @@ const TalkDetailSection: React.FC<TalkDetailCardProps> = ({ talk, lang, onClose 
                 )}
 
                 {/* ハッシュタグラベル（クリック可能） */}
-                {talk.slot?.room && getRoomHashtag(talk.slot.room.id) && (
+                {talk.slot?.room && getRoomHashtag(talk.slot.room.id, talk.code) && (
                   <a
-                    href={`https://x.com/search?q=${encodeURIComponent(getRoomHashtag(talk.slot.room.id) || '')}`}
+                    href={`https://x.com/search?q=${encodeURIComponent(getRoomHashtag(talk.slot.room.id, talk.code) || '')}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center px-3 py-1 bg-blue-100 text-blue-700 text-sm font-bold rounded-full hover:bg-blue-200 transition-all hover:scale-105 cursor-pointer"
                     title={lang === 'ja' ? 'Xで検索' : 'Search on X'}
                   >
-                    {getRoomHashtag(talk.slot.room.id)}
+                    {getRoomHashtag(talk.slot.room.id, talk.code)}
                   </a>
                 )}
 


### PR DESCRIPTION
This pull request includes the following changes:
- Updated the `getRoomHashtag` function to omit hashtags for designated session codes using the `CODES_WITHOUT_ROOM` array.
- Integrated clickable room hashtags in talk and session details to improve navigation.

No new issues were resolved with this pull request