### PR TITLE
Update timetable redirects to point to `day2`

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,12 +25,12 @@ const nextConfig: NextConfig = {
       // タイムテーブルのリダイレクト
       {
         source: '/ja/timetable',
-        destination: '/ja/timetable/day1',
+        destination: '/ja/timetable/day2',
         permanent: false,
       },
       {
         source: '/en/timetable',
-        destination: '/en/timetable/day1',
+        destination: '/en/timetable/day2',
         permanent: false,
       },
       

--- a/src/pages/[lang]/timetable/index.tsx
+++ b/src/pages/[lang]/timetable/index.tsx
@@ -37,7 +37,7 @@ function TimetablePage({ lang }: TimetablePageProps) {
   useEffect(() => {
     // ハッシュフラグメントを保持しながらリダイレクト
     const hash = window.location.hash;
-    void router.replace(`/${lang}/timetable/day1${hash}`);
+    void router.replace(`/${lang}/timetable/day2${hash}`);
   }, [lang, router]);
   
   // リダイレクト中の表示


### PR DESCRIPTION
This pull request updates the timetable redirects and hash handling to now point to `day2` instead of `day1` for both languages. This ensures up-to-date and accurate navigation for users.